### PR TITLE
Fix broken hyperlinks and typos and add new hyperlinks in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -366,7 +366,7 @@ way to use it sacrificing a bit of performance.
 `block_index`, `aad` and `nonce` are optional.
 
 If `nonce` is not provided, on each encrypt operation (`seal_in_place*()`) it will generate a cryptographically secure
-random nonce using `ChaCha20`. You can also provide your own nonce, there is an example below.
+random nonce using `ChaCha20`. You can also provide your own nonce. The [Encrypt and decrypt with a buffer in memory](#encrypt-and-decrypt-with-a-buffer-in-memory) section has an example.
 
 # Security
 
@@ -383,9 +383,7 @@ random nonce using `ChaCha20`. You can also provide your own nonce, there is an 
   passwords or encrryption keys, or any other plaintext sensitive content. Also it's important to zeroize the data when
   not used anymore.**
 - **In the case of [Copy-on-write fork](https://en.wikipedia.org/wiki/Copy-on-write) you need to zeroize the memory
-  before forking the child process**. See here an [example](https://github.com/radumarias/zeroize-python?tab=readme-ov-file#zeroing-memory-before-forking-child-process) for Python.
-
-In the examples below you will see how to do it.
+  before forking the child process**. An [example](#zeroing-memory-before-forking-child-process) using [zeroize-python](https://github.com/radumarias/zeroize-python) is mentioned below.
 
 # Encryption providers and algorithms (ciphers)
 
@@ -535,7 +533,7 @@ been audited.**
 # Examples
 
 You can see more in [examples](https://github.com/radumarias/rencrypt-python/tree/main/examples) directory and
-in [bench.py](https://github.com/radumarias/rencrypt-python/tree/main/bench.py) which has some benchmarks. Here are few
+in [bench.py](https://github.com/radumarias/rencrypt-python/tree/main/benches/bench.py) which has some benchmarks. Here are few
 simple examples:
 
 ## Encrypt and decrypt with a buffer in memory

--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@
 library),`RustCrypto` (`AES-GCM` and `ChaCha20Poly1305` ciphers are audited) but also others which are NOT audited, so
 in principle at least the primitives should offer a similar level of security.**
 
-A Python encryption library implemented in Rust. It supports `AEAD` with varius ciphers. It
+A Python encryption library implemented in Rust. It supports `AEAD` with various ciphers. It
 uses [ring](https://crates.io/crates/ring), [RustCrypto](https://crates.io/crates/aead) (and
-derivates), [sodiumoxide](https://crates.io/crates/sodiumoxide) and [orion](https://crates.io/crates/orion) to handle
+derivatives), [sodiumoxide](https://crates.io/crates/sodiumoxide) and [orion](https://crates.io/crates/orion) to handle
 encryption.
 If offers slightly higher speed compared to other Python libs, especially for small chunks of data (especially
 the `Ring` provider with `AES-GCM` ciphers). The API also tries to be easy to use but it's more optimized for speed than
 usability.
 
-So if you want to use a vast variaety of ciphers and/or achieve the highest possible encryption speed, consider giving
+So if you want to use a vast variety of ciphers and/or achieve the highest possible encryption speed, consider giving
 it a try.
 
 # Benchmark
@@ -27,8 +27,8 @@ fastest among other Python libs like `cryptography`, `NaCl` (`libsodium`), `PyCr
 ## Buffer in memory
 
 This is useful when you keep a buffer, set your plaintext/ciphertext in there, and then encrypt/decrypt in-place in that
-buffer. This is the most performant way to use it, because it does't copy any bytes nor allocate new memory.
-`rencrypt` is faster on small buffers, less than few MB, `PyFLocker` is comming closer for larger buffers.
+buffer. This is the most performant way to use it, because it doesn't copy any bytes nor allocate new memory.
+`rencrypt` is faster on small buffers, less than few MB, `PyFLocker` is coming closer for larger buffers.
 
 **Encrypt seconds**
 ![Encrypt buffer](https://github.com/radumarias/rencrypt-python/blob/main/resources/charts/encrypt.png?raw=true)
@@ -352,11 +352,11 @@ way to use it sacrificing a bit of performance.
 
 1. **With a buffer in memory**: using `seal_in_place()`/`open_in_place()`, is useful when you keep a buffer (or have it
    from somewhere), set your plaintext/ciphertext in there, and then encrypt/decrypt in-place in that buffer. This is
-   the most performant way to use it, because it does't copy any bytes nor allocate new memory.
+   the most performant way to use it, because it doesn't copy any bytes nor allocate new memory.
    **The buffer has to be a `numpy array`**, so that it's easier for you to collect data with slices that reference to
    underlying data. This is because the whole buffer needs to be the size of ciphertext (which is plaintext_len +
    tag_len + nonce_len) but you may pass a slice of the buffer to a BufferedReader to `read_into()` the plaintext.
-   If you can directly collect the data to that buffer, like `BufferedReader.read_into()`, **this is the preffered way
+   If you can directly collect the data to that buffer, like `BufferedReader.read_into()`, **this is the preferred way
    to go**.
 2. **From some bytes into the buffer**: using `seal_in_place_from()`/`open_in_place_from()`, when you have some
    arbitrary data that you want to work with. It will first copy those bytes to the buffer then do the operation
@@ -383,7 +383,7 @@ random nonce using `ChaCha20`. You can also provide your own nonce, there is an 
   passwords or encrryption keys, or any other plaintext sensitive content. Also it's important to zeroize the data when
   not used anymore.**
 - **In the case of [Copy-on-write fork](https://en.wikipedia.org/wiki/Copy-on-write) you need to zeroize the memory
-  before forking the child process.**. See here an [example](https://github.com/radumarias/zeroize-python?tab=readme-ov-file#zeroing-memory-before-forking-child-process) for Python.
+  before forking the child process**. See here an [example](https://github.com/radumarias/zeroize-python?tab=readme-ov-file#zeroing-memory-before-forking-child-process) for Python.
 
 In the examples below you will see how to do it.
 
@@ -391,7 +391,7 @@ In the examples below you will see how to do it.
 
 You will notice in the examples we create the `Cipher` from something like
 this `cipher_meta = CipherMeta.Ring(RingAlgorithm.Aes256Gcm)`. The first part `CipherMeta.Ring` is the encryption
-provider. The last part is the algorithm for that provider, in this case `Aes256Gcm`. Each provier might expose specific
+provider. The last part is the algorithm for that provider, in this case `Aes256Gcm`. Each provider might expose specific
 algorithms.
 
 ## Providers
@@ -409,7 +409,7 @@ enum CipherMeta {
   optimization of a core set of cryptographic operations exposed via an easy-to-use (and hard-to-misuse) API. ring
   exposes a Rust API and is written in a hybrid of Rust, C, and assembly language.
   Particular attention is being paid to making it easy to build and integrate ring into applications and higher-level
-  frameworks, and to ensuring that ring works optimally on small devices, and eventually microcontrollers, to support
+  frameworks, and to ensure that ring works optimally on small devices, and eventually microcontrollers, to support
   Internet of Things (IoT) applications.
   Most of the C and assembly language code in ring comes from BoringSSL, and BoringSSL is derived from OpenSSL. ring
   merges changes from BoringSSL regularly. Also, several changes that were developed for ring have been contributed to
@@ -490,7 +490,7 @@ been audited.**
   implemented in pure software. The underlying `ChaCha20` stream cipher uses a simple combination of `add`, `rotate`,
   and `XOR` instructions (a.k.a. `"ARX"`), and the `Poly1305` hash function is likewise extremely simple.
   With `RustCrypto` provider the underlying `chacha20poly1305` has received one security audit by NCC Group, with no
-  significant findings. With `Ring` provider the underlying `ring` crtate was also audited.
+  significant findings. With `Ring` provider the underlying `ring` crate was also audited.
   If you do not have a hardware acceleration, `ChaCha20Poly1305` is faster than `AES-GCM`.
   While it hasn't received approval from certain standards bodies (i.e. NIST) the algorithm is widely used and deployed.
   Notably it's mandatory to implement in the Transport Layer Security (TLS) protocol. The underlying `ChaCha20` cipher
@@ -649,7 +649,7 @@ if __name__ == "__main__":
 
 You can use other ciphers like `cipher_meta = CipherMeta.Ring(RingAlgorithm.ChaCha20Poly1305)`.
 
-You can also provide your own nonce that you can generate based on your contraints.
+You can also provide your own nonce that you can generate based on your constraints.
 
 ```python
 from rencrypt import Cipher, CipherMeta, RingAlgorithm
@@ -1321,7 +1321,7 @@ python benches/bench.py
     </tbody>
 </table>
 
-## Speed throughput
+## Speed throughout
 
 `256KB` seems to be the sweet spot for buffer size that offers the max `MB/s` speed for encryption, on benchmarks that
 seem to be the case.


### PR DESCRIPTION
Change URL of bench.py from /bench.py to /benches/bench.py and add new hyperlinks for easier navigation to the direct examples or their sections thereof.